### PR TITLE
seagull: use specific idProduct for usb paths

### DIFF
--- a/aosp_d5103.mk
+++ b/aosp_d5103.mk
@@ -48,5 +48,5 @@ PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=320
-
+    ro.sf.lcd_density=320 \
+    ro.usb.pid_suffix=1AD


### PR DESCRIPTION
from 18.1.A.2.25

Signed-off-by: David Viteri davidteri91@gmail.com
