### PR TITLE
seagull: init: Remove unneeded symlink

### DIFF
--- a/rootdir/init.seagull.rc
+++ b/rootdir/init.seagull.rc
@@ -16,9 +16,6 @@ import init.common.rc
 import init.common.usb.rc
 import init.yukon.pwr.rc
 
-on init
-    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
-
 on fs
     mount_all ./fstab.seagull
     write /sys/kernel/boot_adsp/boot 1


### PR DESCRIPTION
This symlink will be created by bootloader
through cmdline parameter:

androidboot.bootdevice=msm_sdcc.1

Signed-off-by: Humberto Borba humberos@gmail.com
