### PR TITLE
macaddr: remove dangerous sepolicy permissions

### DIFF
--- a/rootdir/init.seagull.rc
+++ b/rootdir/init.seagull.rc
@@ -28,6 +28,9 @@ on post-fs-data
     symlink /dev/pn54x /dev/pn547
 
 on boot
+    # Bluetooth
+    chown system system /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr
+
     # Enable writing to led blink node from userspace
     chown system system /sys/class/leds/red/blink
     chown system system /sys/class/leds/green/blink
@@ -40,9 +43,12 @@ on boot
 
 # OSS WLAN setup
 service macaddrsetup /system/bin/macaddrsetup /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr
-    class main
-    user root
+    class core
+    user system
+    group system bluetooth
+    disabled
     oneshot
+    writepid /dev/cpuset/system-background/tasks
 
 # WCNSS service
 service wcnss_service /system/vendor/bin/wcnss_service
@@ -93,6 +99,10 @@ service hciattach /system/bin/sh /system/etc/init.qcom.bt.sh
     group bluetooth system
     disabled
     oneshot
+
+on property:vold.post_fs_data_done=1
+    # Generate Bluetooth MAC address file only when /data is ready
+    start macaddrsetup
 
 on property:bluetooth.hciattach=true
     start hciattach


### PR DESCRIPTION
Write the bluetooth macaddr to a place that is natively readable
by bluetooth services, instead of creating new locations which
requires excessive permissions.

Signed-off-by: Adam Farden adam@farden.cz

Conflicts:
    rootdir/init.kitakami.rc
